### PR TITLE
Early API 16 availability checking

### DIFF
--- a/rxclipboard/src/androidTest/java/com/szagurskii/rxclipboard/RxClipboardTest.java
+++ b/rxclipboard/src/androidTest/java/com/szagurskii/rxclipboard/RxClipboardTest.java
@@ -121,6 +121,102 @@ public class RxClipboardTest {
     o.assertNoMoreEvents();
   }
 
+  @Test public void nullTextAndHtmlChanges() {
+    setClip("Initial");
+    RecordingObserver<String> o = new RecordingObserver<>();
+    Subscription subscription = RxClipboard.textAndHtmlChanges(instrumentation.getContext())
+        .subscribeOn(AndroidSchedulers.mainThread())
+        .subscribe(o);
+    assertThat(o.takeNext()).isEqualTo("Initial");
+
+    setAndAssert(o, "Next");
+    setAndAssert(o, null, "");
+    setAndAssert(o, null, "");
+    setAndAssert(o, "Stuff");
+    setAndAssert(o, null, "");
+    setAndAssert(o, null, "");
+    setAndAssert(o, "Works?");
+    setAndAssert(o, null, "");
+    setAndAssert(o, null, "");
+
+    subscription.unsubscribe();
+
+    setClip("", null);
+    o.assertNoMoreEvents();
+  }
+
+  @Test public void initialNullTextAndHtmlChanges() {
+    setClip("Initial", null);
+    RecordingObserver<String> o = new RecordingObserver<>();
+    Subscription subscription = RxClipboard.textAndHtmlChanges(instrumentation.getContext())
+        .subscribeOn(AndroidSchedulers.mainThread())
+        .subscribe(o);
+    assertThat(o.takeNext()).isEqualTo("");
+
+    setAndAssert(o, "Next");
+    setAndAssert(o, null, "");
+    setAndAssert(o, null, "");
+    setAndAssert(o, "Stuff");
+    setAndAssert(o, null, "");
+    setAndAssert(o, null, "");
+    setAndAssert(o, "Works?");
+    setAndAssert(o, null, "");
+    setAndAssert(o, null, "");
+
+    subscription.unsubscribe();
+
+    setClip("", null);
+    o.assertNoMoreEvents();
+  }
+
+  @Test public void nullHtmlChanges() {
+    setHtmlClip("Initial");
+    RecordingObserver<String> o = new RecordingObserver<>();
+    Subscription subscription = RxClipboard.htmlChanges(instrumentation.getContext())
+        .subscribeOn(AndroidSchedulers.mainThread())
+        .subscribe(o);
+    assertThat(o.takeNext()).isEqualTo("Initial");
+
+    setHtmlAndAssert(o, "Next");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, "Stuff");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, "Works?");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, null, "");
+
+    subscription.unsubscribe();
+
+    setClip("", null);
+    o.assertNoMoreEvents();
+  }
+
+  @Test public void initialNullHtmlChanges() {
+    setHtmlClip("Initial", null);
+    RecordingObserver<String> o = new RecordingObserver<>();
+    Subscription subscription = RxClipboard.htmlChanges(instrumentation.getContext())
+        .subscribeOn(AndroidSchedulers.mainThread())
+        .subscribe(o);
+    assertThat(o.takeNext()).isEqualTo("");
+
+    setHtmlAndAssert(o, "Next");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, "Stuff");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, "Works?");
+    setHtmlAndAssert(o, null, "");
+    setHtmlAndAssert(o, null, "");
+
+    subscription.unsubscribe();
+
+    setClip("", null);
+    o.assertNoMoreEvents();
+  }
+
   @Test public void textAndHtmlChanges() {
     setClip("Initial");
     RecordingObserver<String> o = new RecordingObserver<>();
@@ -402,6 +498,11 @@ public class RxClipboardTest {
     assertThat(o.takeNext()).isEqualTo(value);
   }
 
+  void setHtmlAndAssert(RecordingObserver<String> o, final String value, final String assertionString) {
+    setHtmlClip(value);
+    assertThat(o.takeNext()).isEqualTo(assertionString);
+  }
+
   private void assertClipData(RecordingObserver<ClipData> o, ClipData value) {
     assertThat(o.takeNext().toString()).isEqualTo(value.toString());
   }
@@ -436,5 +537,9 @@ public class RxClipboardTest {
 
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN) void setHtmlClip(@NonNull String clip) {
     setClip(ClipData.newHtmlText("Html", "Basic", clip));
+  }
+
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN) void setHtmlClip(@NonNull String label, @Nullable String clip) {
+    setClip(ClipData.newHtmlText(label, clip, clip));
   }
 }

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardHtmlOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardHtmlOnSubscribe.java
@@ -41,8 +41,8 @@ final class ClipboardHtmlOnSubscribe implements Observable.OnSubscribe<String> {
   private void propagate(Subscriber<? super String> subscriber) {
     if (clipboard.hasPrimaryClip()) {
       ClipData cd = clipboard.getPrimaryClip();
-      if (cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML)) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+        if (cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML)) {
           subscriber.onNext(cd.getItemAt(0).getHtmlText());
         }
       }

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardHtmlOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardHtmlOnSubscribe.java
@@ -43,7 +43,8 @@ final class ClipboardHtmlOnSubscribe implements Observable.OnSubscribe<String> {
       ClipData cd = clipboard.getPrimaryClip();
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
         if (cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML)) {
-          subscriber.onNext(cd.getItemAt(0).getHtmlText());
+          String htmlText = cd.getItemAt(0).getHtmlText();
+          subscriber.onNext(htmlText == null ? "" : htmlText);
         }
       }
     }

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardStringOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardStringOnSubscribe.java
@@ -52,10 +52,8 @@ final class ClipboardStringOnSubscribe implements Observable.OnSubscribe<String>
       ClipData cd = clipboard.getPrimaryClip();
       if (cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
         subscriber.onNext(cd.getItemAt(0).getText().toString());
-      } else if (cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML)) {
-        if (propagateHtml && JB) {
-          subscriber.onNext(cd.getItemAt(0).getHtmlText());
-        }
+      } else if (propagateHtml && JB && cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML)) {
+        subscriber.onNext(cd.getItemAt(0).getHtmlText());
       }
     }
   }

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardStringOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardStringOnSubscribe.java
@@ -54,8 +54,8 @@ final class ClipboardStringOnSubscribe implements Observable.OnSubscribe<String>
         CharSequence clip = cd.getItemAt(0).getText();
         subscriber.onNext(clip == null ? "" : clip.toString());
       } else if (propagateHtml && JB && cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML)) {
-      	CharSequence clip = cd.getItemAt(0).getText();
-        subscriber.onNext(clip == null ? "" : clip.getHtmlText());
+        String htmlText = cd.getItemAt(0).getHtmlText();
+        subscriber.onNext(htmlText == null ? "" : htmlText);
       }
     }
   }


### PR DESCRIPTION
- Fix: When subscring to `html` changes updates, first check whether current platform supports `html` changes. (API>=16)
