### PR TITLE
Remove creation of synthetic accessor method.

### DIFF
--- a/rxclipboard-sample/src/main/java/com/szagurskii/rxclipboard/sample/MainActivity.java
+++ b/rxclipboard-sample/src/main/java/com/szagurskii/rxclipboard/sample/MainActivity.java
@@ -13,7 +13,7 @@ import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 
 public class MainActivity extends Activity {
-  private static final String TAG = MainActivity.class.getSimpleName();
+  static final String TAG = MainActivity.class.getSimpleName();
 
   private Subscription subscription;
 

--- a/rxclipboard/src/androidTest/java/com/szagurskii/rxclipboard/RecordingObserver.java
+++ b/rxclipboard/src/androidTest/java/com/szagurskii/rxclipboard/RecordingObserver.java
@@ -70,7 +70,7 @@ public final class RecordingObserver<T> implements Observer<T> {
   private final class OnNext {
     final T value;
 
-    private OnNext(T value) {
+    OnNext(T value) {
       this.value = value;
     }
 
@@ -80,15 +80,18 @@ public final class RecordingObserver<T> implements Observer<T> {
   }
 
   private final class OnCompleted {
+    OnCompleted() {
+    }
+
     @Override public String toString() {
       return "OnCompleted";
     }
   }
 
   private final class OnError {
-    private final Throwable throwable;
+    final Throwable throwable;
 
-    private OnError(Throwable throwable) {
+    OnError(Throwable throwable) {
       this.throwable = throwable;
     }
 

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardClipOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardClipOnSubscribe.java
@@ -12,7 +12,7 @@ import rx.Subscriber;
  * @author Savelii Zagurskii
  */
 final class ClipboardClipOnSubscribe implements Observable.OnSubscribe<ClipData> {
-  @NonNull private final ClipboardManager clipboard;
+  @NonNull final ClipboardManager clipboard;
 
   public ClipboardClipOnSubscribe(@NonNull ClipboardManager clipboard) {
     this.clipboard = clipboard;
@@ -37,7 +37,7 @@ final class ClipboardClipOnSubscribe implements Observable.OnSubscribe<ClipData>
     propagate(subscriber);
   }
 
-  private void propagate(@NonNull Subscriber<? super ClipData> subscriber) {
+  void propagate(@NonNull Subscriber<? super ClipData> subscriber) {
     if (clipboard.hasPrimaryClip()) {
       subscriber.onNext(clipboard.getPrimaryClip());
     }

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardHtmlOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardHtmlOnSubscribe.java
@@ -17,7 +17,7 @@ import rx.Subscriber;
 final class ClipboardHtmlOnSubscribe implements Observable.OnSubscribe<String> {
   private static final boolean JB = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
 
-  @NonNull private final ClipboardManager clipboard;
+  @NonNull final ClipboardManager clipboard;
 
   public ClipboardHtmlOnSubscribe(@NonNull ClipboardManager clipboard) {
     this.clipboard = clipboard;
@@ -42,7 +42,7 @@ final class ClipboardHtmlOnSubscribe implements Observable.OnSubscribe<String> {
     propagate(subscriber);
   }
 
-  @SuppressLint("NewApi") private void propagate(@NonNull Subscriber<? super String> subscriber) {
+  @SuppressLint("NewApi") void propagate(@NonNull Subscriber<? super String> subscriber) {
     if (clipboard.hasPrimaryClip()) {
       ClipData cd = clipboard.getPrimaryClip();
       if (JB) {

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardIntentOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardIntentOnSubscribe.java
@@ -14,7 +14,7 @@ import rx.Subscriber;
  * @author Savelii Zagurskii
  */
 final class ClipboardIntentOnSubscribe implements Observable.OnSubscribe<Intent> {
-  @NonNull private final ClipboardManager clipboard;
+  @NonNull final ClipboardManager clipboard;
 
   public ClipboardIntentOnSubscribe(@NonNull ClipboardManager clipboard) {
     this.clipboard = clipboard;
@@ -39,7 +39,7 @@ final class ClipboardIntentOnSubscribe implements Observable.OnSubscribe<Intent>
     propagate(subscriber);
   }
 
-  private void propagate(@NonNull Subscriber<? super Intent> subscriber) {
+  void propagate(@NonNull Subscriber<? super Intent> subscriber) {
     if (clipboard.hasPrimaryClip()) {
       ClipData cd = clipboard.getPrimaryClip();
       if (cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_INTENT)) {

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardStringOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardStringOnSubscribe.java
@@ -17,7 +17,7 @@ import rx.Subscriber;
 final class ClipboardStringOnSubscribe implements Observable.OnSubscribe<String> {
   private static final boolean JB = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
 
-  @NonNull private final ClipboardManager clipboard;
+  @NonNull final ClipboardManager clipboard;
   private final boolean propagateHtml;
 
   public ClipboardStringOnSubscribe(@NonNull ClipboardManager clipboard) {
@@ -48,7 +48,7 @@ final class ClipboardStringOnSubscribe implements Observable.OnSubscribe<String>
     propagate(subscriber);
   }
 
-  @SuppressLint("NewApi") private void propagate(@NonNull Subscriber<? super String> subscriber) {
+  @SuppressLint("NewApi") void propagate(@NonNull Subscriber<? super String> subscriber) {
     if (clipboard.hasPrimaryClip()) {
       ClipData cd = clipboard.getPrimaryClip();
       if (cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {

--- a/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardUriOnSubscribe.java
+++ b/rxclipboard/src/main/java/com/szagurskii/rxclipboard/ClipboardUriOnSubscribe.java
@@ -14,7 +14,7 @@ import rx.Subscriber;
  * @author Savelii Zagurskii
  */
 final class ClipboardUriOnSubscribe implements Observable.OnSubscribe<Uri> {
-  @NonNull private final ClipboardManager clipboard;
+  @NonNull final ClipboardManager clipboard;
 
   public ClipboardUriOnSubscribe(@NonNull ClipboardManager clipboard) {
     this.clipboard = clipboard;
@@ -39,7 +39,7 @@ final class ClipboardUriOnSubscribe implements Observable.OnSubscribe<Uri> {
     propagate(subscriber);
   }
 
-  private void propagate(@NonNull Subscriber<? super Uri> subscriber) {
+  void propagate(@NonNull Subscriber<? super Uri> subscriber) {
     if (clipboard.hasPrimaryClip()) {
       ClipData cd = clipboard.getPrimaryClip();
       if (cd.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_URILIST)) {


### PR DESCRIPTION
- `rxclipboard`: Removes 10 methods to 80 from 90.
