### PR TITLE
remove RxAndroid dependency from library

### DIFF
--- a/rxclipboard-sample/build.gradle
+++ b/rxclipboard-sample/build.gradle
@@ -42,4 +42,5 @@ android {
 
 dependencies {
   compile project(':rxclipboard')
+  compile libraries.rxAndroid
 }

--- a/rxclipboard/build.gradle
+++ b/rxclipboard/build.gradle
@@ -39,7 +39,6 @@ android {
 
 dependencies {
   compile libraries.rxJava
-  compile libraries.rxAndroid
   compile libraries.supportAnnotations
 
   androidTestCompile libraries.junit
@@ -49,6 +48,7 @@ dependencies {
   androidTestCompile libraries.espressoCore
   androidTestCompile libraries.espressoContrib
   androidTestCompile libraries.awaitility
+  androidTestCompile libraries.rxAndroid
 
   testCompile libraries.junit
   testCompile libraries.truth


### PR DESCRIPTION
RxAndroid was a dependency in RxClipboard even though it is not used
in the library itself, only in the androidTest flavor.